### PR TITLE
Update string in SaveQueryForm to match template

### DIFF
--- a/AzureExtension/Controls/Forms/SaveQueryForm.cs
+++ b/AzureExtension/Controls/Forms/SaveQueryForm.cs
@@ -110,7 +110,7 @@ public sealed partial class SaveQueryForm : FormContent, IAzureForm
 
     public Query CreateQueryFromJson(JsonNode? jsonNode)
     {
-        var queryUrl = jsonNode?["EnteredSearch"]?.ToString() ?? string.Empty;
+        var queryUrl = jsonNode?["EnteredQuery"]?.ToString() ?? string.Empty;
         var name = jsonNode?["Name"]?.ToString() ?? string.Empty;
         var isTopLevel = jsonNode?["IsTopLevel"]?.ToString() == "true";
 


### PR DESCRIPTION
Before:
- A bad merge left the former "EnteredSearch" string in `CreateQueryFromJson`, which prevented queries from being saved.

After:
- The string is now updated to "EnteredQuery" to match the id in `SaveQueryFormTemplate`