### PR TITLE
Fixing bugs on form flow

### DIFF
--- a/AzureExtension/Controls/ISavedSearchesUpdater.cs
+++ b/AzureExtension/Controls/ISavedSearchesUpdater.cs
@@ -13,7 +13,9 @@ public interface ISavedSearchesUpdater<TDataSearch>
 {
     void RemoveSavedSearch(TDataSearch search);
 
-    Task AddOrUpdateSearch(TDataSearch search, bool isTopLevel, IAccount account);
+    void AddOrUpdateSearch(TDataSearch search, bool isTopLevel);
 
     bool IsTopLevel(TDataSearch search);
+
+    Task Validate(TDataSearch search, IAccount account);
 }

--- a/AzureExtension/PersistentData/DefinitionSearch/DefinitionSearchRepository.cs
+++ b/AzureExtension/PersistentData/DefinitionSearch/DefinitionSearchRepository.cs
@@ -72,6 +72,11 @@ public class DefinitionSearchRepository : IPersistentSearchRepository<IPipelineD
         return _azureValidator.GetDefinitionInfo(definitionSearch.ProjectUrl, definitionSearch.InternalId, account);
     }
 
+    public Task Validate(IPipelineDefinitionSearch search, IAccount account)
+    {
+        return ValidateDefinitionSearch(search, account);
+    }
+
     public void UpdateDefinitionSearchTopLevelStatus(IPipelineDefinitionSearch definitionSearch, bool isTopLevel, IAccount account)
     {
         ValidateDataStore();
@@ -132,10 +137,9 @@ public class DefinitionSearchRepository : IPersistentSearchRepository<IPipelineD
         return definitions;
     }
 
-    public async Task AddOrUpdateSearch(IPipelineDefinitionSearch dataSearch, bool isTopLevel, IAccount account)
+    public void AddOrUpdateSearch(IPipelineDefinitionSearch dataSearch, bool isTopLevel)
     {
         ValidateDataStore();
-        await ValidateDefinitionSearch(dataSearch, account);
         DefinitionSearch.AddOrUpdate(_dataStore, dataSearch.InternalId, dataSearch.ProjectUrl, isTopLevel);
     }
 

--- a/AzureExtension/PersistentData/PullRequestSearch/PullRequestSearchRepository.cs
+++ b/AzureExtension/PersistentData/PullRequestSearch/PullRequestSearchRepository.cs
@@ -32,9 +32,14 @@ public class PullRequestSearchRepository : IPersistentSearchRepository<IPullRequ
         _dataStore = dataStore;
     }
 
-    public Task ValidatePullRequestSearch(IPullRequestSearch pullRequestSearch, IAccount account)
+    private Task ValidatePullRequestSearch(IPullRequestSearch pullRequestSearch, IAccount account)
     {
         return _azureValidator.GetRepositoryInfo(pullRequestSearch.Url, account);
+    }
+
+    public Task Validate(IPullRequestSearch search, IAccount account)
+    {
+        return ValidatePullRequestSearch(search, account);
     }
 
     public void RemoveSavedSearch(IPullRequestSearch dataSearch)
@@ -83,10 +88,9 @@ public class PullRequestSearchRepository : IPersistentSearchRepository<IPullRequ
         return dstorePullRequestSearch != null && dstorePullRequestSearch.IsTopLevel;
     }
 
-    public async Task AddOrUpdateSearch(IPullRequestSearch dataSearch, bool isTopLevel, IAccount account)
+    public void AddOrUpdateSearch(IPullRequestSearch dataSearch, bool isTopLevel)
     {
         ValidateDataStore();
-        await ValidatePullRequestSearch(dataSearch, account);
         PullRequestSearch.AddOrUpdate(_dataStore, dataSearch.Url, dataSearch.Name, dataSearch.View, isTopLevel);
     }
 

--- a/AzureExtension/PersistentData/QuerySearch/QueryRepository.cs
+++ b/AzureExtension/PersistentData/QuerySearch/QueryRepository.cs
@@ -40,10 +40,15 @@ public partial class QueryRepository : IPersistentSearchRepository<IQuery>
         return dsQuery != null && dsQuery.IsTopLevel;
     }
 
-    public async Task<bool> ValidateQuery(IQuery query, IAccount account)
+    private async Task<bool> ValidateQuery(IQuery query, IAccount account)
     {
         var queryInfo = await _azureValidator.GetQueryInfo(query.Url, account);
         return queryInfo.Result == ResultType.Success;
+    }
+
+    public Task Validate(IQuery search, IAccount account)
+    {
+        return ValidateQuery(search, account);
     }
 
     public void RemoveSavedSearch(IQuery dataSearch)
@@ -83,10 +88,9 @@ public partial class QueryRepository : IPersistentSearchRepository<IQuery>
         return Query.GetAll(_dataStore);
     }
 
-    public async Task AddOrUpdateSearch(IQuery dataSearch, bool isTopLevel, IAccount account)
+    public void AddOrUpdateSearch(IQuery dataSearch, bool isTopLevel)
     {
         ValidateDataStore();
-        await ValidateQuery(dataSearch, account);
         Query.AddOrUpdate(_dataStore, dataSearch.Name, dataSearch.Url, isTopLevel);
     }
 


### PR DESCRIPTION
We were deleting previous searches if the validation fails, now it happens before we delete and updates the search.
This might create a temporal coupling on the updater API, but I think it is fine.

Also fixed the bug where if you save the search twice in the same form, it would crash by trying to delete one that doesn't exist anymore. Now we swap the saved searches instances in the form variable.