### PR TITLE
Getting IDefinition from the live data provider

### DIFF
--- a/AzureExtension/Controls/SearchPages/BuildSearchPage.cs
+++ b/AzureExtension/Controls/SearchPages/BuildSearchPage.cs
@@ -55,10 +55,10 @@ public partial class BuildSearchPage : ListPage
 
     private IconInfo GetIcon()
     {
-        var builds = _dataProvider.GetBuilds(_search).GetAwaiter().GetResult();
-        if (builds != null && builds.Any())
+        var lastBuild = _definition.MostRecentBuild;
+        if (lastBuild != null)
         {
-            return IconLoader.GetIconForPipelineStatusAndResult(builds.First().Status, builds.First().Result);
+            return IconLoader.GetIconForPipelineStatusAndResult(lastBuild.Status, lastBuild.Result);
         }
 
         return IconLoader.GetIcon("Logo");

--- a/AzureExtension/Controls/SearchPages/SearchPageFactory.cs
+++ b/AzureExtension/Controls/SearchPages/SearchPageFactory.cs
@@ -142,7 +142,7 @@ public class SearchPageFactory : ISearchPageFactory
 
     public IListItem CreateItemForDefinitionSearch(IPipelineDefinitionSearch search)
     {
-        var definition = _definitionRepository.GetSavedData(search);
+        var definition = _dataProvider.GetDefinition(search).Result;
         var timeSpanHelper = new TimeSpanHelper(_resources);
 
         var azureSearchRepository = _azureSearchRepositories[typeof(IPipelineDefinitionSearch)];


### PR DESCRIPTION
I changed my mind and I think the Search Repository should only be responsible by managing searches (inputs from the user) and not Live Datas (this is for the Live Data provider to provide).

This way, there is a SRP for this classes and a better API. We also will know easily where a possible bug is originating from.