### PR TITLE
Check if the default account is null before setting the sign out button

### DIFF
--- a/AzureExtension/Controls/Forms/SignInForm.cs
+++ b/AzureExtension/Controls/Forms/SignInForm.cs
@@ -21,6 +21,15 @@ public partial class SignInForm : FormContent
     private string IsButtonEnabled =>
         _isButtonEnabled.ToString(CultureInfo.InvariantCulture).ToLower(CultureInfo.InvariantCulture);
 
+    public Dictionary<string, string> TemplateSubstitutions => new()
+    {
+        { "{{AuthTitle}}", _resources.GetResource("Forms_SignIn_TemplateAuthTitle") },
+        { "{{AuthButtonTitle}}", _resources.GetResource("Forms_SignIn_TemplateAuthButtonTitle") },
+        { "{{AuthIcon}}", $"data:image/png;base64,{IconLoader.GetIconAsBase64("Logo")}" },
+        { "{{AuthButtonTooltip}}", _resources.GetResource("Forms_SignIn_TemplateAuthButtonTooltip") },
+        { "{{ButtonIsEnabled}}", IsButtonEnabled },
+    };
+
     public SignInForm(AuthenticationMediator authenticationMediator, IResources resources, SignInCommand signInCommand)
     {
         _authenticationMediator = authenticationMediator;
@@ -50,15 +59,6 @@ public partial class SignInForm : FormContent
         TemplateJson = TemplateHelper.LoadTemplateJsonFromTemplateName("AuthTemplate", TemplateSubstitutions);
         OnPropertyChanged(nameof(TemplateJson));
     }
-
-    public Dictionary<string, string> TemplateSubstitutions => new()
-    {
-        { "{{AuthTitle}}", _resources.GetResource("Forms_SignIn_TemplateAuthTitle") },
-        { "{{AuthButtonTitle}}", _resources.GetResource("Forms_SignIn_TemplateAuthButtonTitle") },
-        { "{{AuthIcon}}", $"data:image/png;base64,{IconLoader.GetIconAsBase64("Logo")}" },
-        { "{{AuthButtonTooltip}}", _resources.GetResource("Forms_SignIn_TemplateAuthButtonTooltip") },
-        { "{{ButtonIsEnabled}}", IsButtonEnabled },
-    };
 
     public override string TemplateJson => TemplateHelper.LoadTemplateJsonFromTemplateName("AuthTemplate", TemplateSubstitutions);
 

--- a/AzureExtension/Controls/Forms/SignOutForm.cs
+++ b/AzureExtension/Controls/Forms/SignOutForm.cs
@@ -8,7 +8,6 @@ using AzureExtension.Controls.Commands;
 using AzureExtension.Helpers;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
-using Microsoft.Identity.Client;
 
 namespace AzureExtension.Controls.Forms;
 
@@ -19,6 +18,15 @@ public sealed partial class SignOutForm : FormContent
     private readonly AuthenticationMediator _authenticationMediator;
     private readonly IAccountProvider _accountProvider;
     private bool _isButtonEnabled = true;
+
+    public Dictionary<string, string> TemplateSubstitutions => new()
+    {
+        { "{{AuthTitle}}", _resources.GetResource("Forms_SignOut_TemplateAuthTitle") },
+        { "{{AuthButtonTitle}}", $"{_resources.GetResource("Forms_SignOut_TemplateAuthButtonTitle")} {_accountProvider.GetDefaultAccount()?.Username ?? string.Empty}" },
+        { "{{AuthIcon}}", $"data:image/png;base64,{IconLoader.GetIconAsBase64("Logo")}" },
+        { "{{AuthButtonTooltip}}", _resources.GetResource("Forms_SignOut_TemplateAuthButtonTooltip") },
+        { "{{ButtonIsEnabled}}", IsButtonEnabled },
+    };
 
     private string IsButtonEnabled =>
         _isButtonEnabled.ToString(CultureInfo.InvariantCulture).ToLower(CultureInfo.InvariantCulture);
@@ -46,16 +54,6 @@ public sealed partial class SignOutForm : FormContent
             SetButtonEnabled(false);
         }
     }
-
-    // ButtonIsEnabled is set to true by default. Nothing currently changes this value
-    public Dictionary<string, string> TemplateSubstitutions => new()
-    {
-        { "{{AuthTitle}}", _resources.GetResource("Forms_SignOut_TemplateAuthTitle") },
-        { "{{AuthButtonTitle}}", $"{_resources.GetResource("Forms_SignOut_TemplateAuthButtonTitle")} {_accountProvider.GetDefaultAccount().Username}" },
-        { "{{AuthIcon}}", $"data:image/png;base64,{IconLoader.GetIconAsBase64("Logo")}" },
-        { "{{AuthButtonTooltip}}", _resources.GetResource("Forms_SignOut_TemplateAuthButtonTooltip") },
-        { "{{ButtonIsEnabled}}", IsButtonEnabled },
-    };
 
     private void SetButtonEnabled(bool isEnabled)
     {


### PR DESCRIPTION
Before:
- The auth forms started throwing null reference exceptions because sign out form wasn't checking if an account existed before trying to add the authenticated account name to the sign out button

After:
- Null checks :)
- I also moved the `TemplateSubstitutions` property towards the top so it would be near the other properties in the class