### PR TITLE
Changing to run arm tests on arm

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,17 +12,15 @@ jobs:
   build-and-test:
     strategy:
       matrix:
-        configuration: [Release, Debug]
+        configuration: [Release]
         platform: [x64, arm64]
-        os: [windows-latest]
+        os: [windows-latest, windows-11-arm]
         dotnet-version: ['8.0.x']
         exclude:
-        - configuration: Debug
-          platform: x64
-        - configuration: Release
-          platform: x86
-        - configuration: Debug
+        - os: windows-latest
           platform: arm64
+        - os: windows-11-arm
+          platform: x64
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request updates the CI workflow configuration to optimize the build-and-test matrix by removing unnecessary configurations and adding support for Windows 11 on ARM architecture.

Changes to CI workflow configuration:

* [`.github/workflows/CI.yml`](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L15-R23): Removed the `Debug` configuration and `x86` platform from the matrix, simplifying the build process.
* [`.github/workflows/CI.yml`](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L15-R23): Added support for `windows-11-arm` to the `os` matrix, enabling testing on Windows 11 ARM architecture.