### PR TITLE
Update outdated packages

### DIFF
--- a/AzureExtension.Test/AzureExtension.Test.csproj
+++ b/AzureExtension.Test/AzureExtension.Test.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="System.Drawing.Common" Version="9.0.4" />
+    <PackageReference Include="System.Formats.Asn1" Version="6.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Private.Uri" Version="4.3.2" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.4" />

--- a/AzureExtension/AzureExtension.csproj
+++ b/AzureExtension/AzureExtension.csproj
@@ -55,6 +55,7 @@
         <PackageReference Include="Shmuelie.WinRTServer" Version="2.1.1" />
         <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.0-preview.2.25163.2" />
         <PackageReference Include="System.Drawing.Common" Version="9.0.4" />
+        <PackageReference Include="System.Formats.Asn1" Version="6.0.1" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
         <PackageReference Include="System.Private.Uri" Version="4.3.2" />
         <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.4" />


### PR DESCRIPTION
This pull request intends to update transient packages to more secure versions. The current fix adds top-level package references instead of updating the library that has dependencies on the package.