### PR TITLE
Changing update threshold to 1 minute

### DIFF
--- a/AzureExtension/DataModel/DataObjects/Definition.cs
+++ b/AzureExtension/DataModel/DataObjects/Definition.cs
@@ -14,7 +14,7 @@ namespace AzureExtension.DataModel;
 [Table("Definition")]
 public class Definition : IDefinition
 {
-    private static readonly long _updateThreshold = TimeSpan.FromHours(4).Ticks;
+    private static readonly long _updateThreshold = TimeSpan.FromMinutes(1).Ticks;
 
     [Key]
     public long Id { get; set; } = DataStore.NoForeignKey;


### PR DESCRIPTION
This pull request includes a single change to the `Definition` class in the `AzureExtension.DataModel` namespace. The `_updateThreshold` value was reduced from 4 hours to 1 minute to adjust the update frequency.