### PR TITLE
Bump System.Security.Cryptography.Xml to 9.0.15 to fix Dependabot alerts

### DIFF
--- a/AzureExtension.Test/AzureExtension.Test.csproj
+++ b/AzureExtension.Test/AzureExtension.Test.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="System.Drawing.Common" Version="9.0.4" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.4" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.15" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AzureExtension/AzureExtension.csproj
+++ b/AzureExtension/AzureExtension.csproj
@@ -55,7 +55,7 @@
         <PackageReference Include="Shmuelie.WinRTServer" Version="2.1.1" />
         <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.0-preview.2.25163.2" />
         <PackageReference Include="System.Drawing.Common" Version="9.0.4" />
-        <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.4" />
+        <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.15" />
         <PackageReference Include="System.Text.Json" Version="9.0.0" />
 	</ItemGroup>
 


### PR DESCRIPTION
## Summary

Resolves all 4 open Dependabot alerts (high severity) by upgrading the vulnerable NuGet package `System.Security.Cryptography.Xml` from `9.0.4` to `9.0.15`.

The previous version `9.0.4` falls within the vulnerable range (`>= 9.0.0, <= 9.0.14`). `9.0.15` is the recommended patched release.

## Advisories addressed

- **CVE-2026-26171** — .NET Denial of Service Vulnerability
- **CVE-2026-33116** — .NET / .NET Framework / Visual Studio Denial of Service Vulnerability

## Changes

- `AzureExtension/AzureExtension.csproj`: `System.Security.Cryptography.Xml` `9.0.4` → `9.0.15`
- `AzureExtension.Test/AzureExtension.Test.csproj`: `System.Security.Cryptography.Xml` `9.0.4` → `9.0.15`

## Verification

- `dotnet restore` succeeds; both projects resolve `System.Security.Cryptography.Xml/9.0.15` (x64 and arm64).
- The main `AzureExtension` project builds successfully and produces its DLL/MSIX.
