### PR TITLE
Update Windows App SDK to 2.2.0

### DIFF
--- a/AzureExtension/AzureExtension.csproj
+++ b/AzureExtension/AzureExtension.csproj
@@ -18,7 +18,7 @@
 		<GenerateTestArtifacts>True</GenerateTestArtifacts>
 		<HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
 		<GenerateAppxPackageOnBuild>True</GenerateAppxPackageOnBuild>
-		<WindowsAppSdkDeploymentManagerInitialize>false</WindowsAppSdkDeploymentManagerInitialize>
+		<WindowsAppSdkDeploymentManagerInitialize>False</WindowsAppSdkDeploymentManagerInitialize>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/AzureExtension/AzureExtension.csproj
+++ b/AzureExtension/AzureExtension.csproj
@@ -18,6 +18,7 @@
 		<GenerateTestArtifacts>True</GenerateTestArtifacts>
 		<HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
 		<GenerateAppxPackageOnBuild>True</GenerateAppxPackageOnBuild>
+		<WindowsAppSdkDeploymentManagerInitialize>false</WindowsAppSdkDeploymentManagerInitialize>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -43,7 +44,7 @@
         <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="19.253.0-preview" />
         <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="19.253.0-preview" />
         <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.2.206-beta" />
-        <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.241114003" />
+        <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.2.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="Octokit" Version="10.0.0" />
         <PackageReference Include="Serilog" Version="4.0.1" />


### PR DESCRIPTION
## Summary

Upgrades **Windows App SDK** from `1.6.241114003` to `2.2.0`, and opts out of the Deployment Manager auto-initializer that newer WASDK enables by default.

## Changes

- `AzureExtension/AzureExtension.csproj`:
  - `Microsoft.WindowsAppSDK` `1.6.241114003` → `2.2.0`
  - Added `<WindowsAppSdkDeploymentManagerInitialize>false</WindowsAppSdkDeploymentManagerInitialize>`

## Why the Deployment Manager opt-out

Starting in **WASDK 1.8+**, the Deployment Manager auto-initializer (a module initializer calling `DeploymentManager.Initialize()`) runs **by default**. This was verified empirically:

| Build | `DeploymentManager` injected into `AzureExtension.dll`? |
|---|---|
| WASDK 1.6 | No |
| WASDK 2.2.0 (default) | Yes |
| WASDK 2.2.0 + property `false` | No |

This extension is a packaged `runFullTrust` COM-server Command Palette extension that does not use Main/Singleton package functionality (e.g. push notifications, the Deployment API) and does not declare the `packageManagement` restricted capability. Per [Microsoft guidance](https://learn.microsoft.com/en-us/windows/apps/package-and-deploy/project-properties#the-deployment-manager-auto-initializer), apps on WASDK 1.8+ that don't need Main/Singleton packages should opt out, so the auto-initializer's startup call is unnecessary here (and a potential failure path).

## Verification

- `dotnet restore` resolves `Microsoft.WindowsAppSDK/2.2.0` (x64 and arm64).
- The main `AzureExtension` project builds successfully (DLL + MSIX); only pre-existing CA1859/NETSDK1198 warnings.
- After adding the opt-out, the built DLL no longer contains the injected `DeploymentManager` initializer.

## Notes

- The unit test project could not be built/run in the author's environment due to a pre-existing, unrelated missing Visual Studio Appx/PRI MSBuild task assembly (`Microsoft.Build.Packaging.Pri.Tasks.dll`). CI should exercise the tests.
