### PR TITLE
Add least-privilege permissions block to CI workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,6 +8,9 @@ on:
   push:
     branches: [ "main", "dev" ]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     strategy:


### PR DESCRIPTION
## Summary

Resolves the open CodeQL code-scanning alert **`actions/missing-workflow-permissions`** (medium severity) on `.github/workflows/CI.yml`.

The CI workflow did not declare an explicit `permissions` block, so it inherited the repository/organization default scope for `GITHUB_TOKEN`. CodeQL flags this because it may grant more than the principle of least privilege requires.

## Change

Added a root-level least-privilege permissions block to `.github/workflows/CI.yml`:

```yaml
permissions:
  contents: read
```

The `build-and-test` job only checks out the repo, restores, builds, and runs tests — it performs no writes — so `contents: read` is sufficient.

## Consistency

This mirrors the same fix already applied to the sibling **CmdPalGitHubExtension** repo, whose `CI.yml` declares the identical `permissions: contents: read` block at the workflow root.

## Verification

- Workflow YAML parses correctly; the `permissions` key resolves to `{ contents: read }` and the `build-and-test` job is unchanged.
